### PR TITLE
Fab task `local.system.deploy` not found

### DIFF
--- a/docs/getting-started/dev-environment.md
+++ b/docs/getting-started/dev-environment.md
@@ -129,7 +129,7 @@ The first time you run those tasks, it will take quite some time… You may want
 You can run this task:
 
 ```bash
-fab local.system.deploy
+fab local.app.deploy
 ```
 
 :::tip


### PR DESCRIPTION
#### Description

Documentation refers to an undefined fab task `local.system.deploy`.

See output of `fab --list | grep deploy` =>
```
  ci.app.deploy
  local.app.deploy
```

#### Suggestion

I am not sure but I think wanted task is `fab local.app.deploy` ? 
According to [task file](https://github.com/cap-collectif/cap-collectif/blob/main/infrastructure/deploylib/local/app.py#L24)

Thank you